### PR TITLE
fix: change EDITPAGE_PATTERN

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -105,7 +105,7 @@ function setup(): void {
  */
 function isTargetPage(url: string): boolean {
   // The url pattern of editpage
-  const EDITPAGE_PATTERN = /editpage\.action\?pageId=\d+$/;
+  const EDITPAGE_PATTERN = /editpage\.action$/;
   // The url pattern of createpage
   const CREATEPAGE_PATTERN = /createpage\.action/;
   // Determine the given url whether it is "editpage" or "createpage"


### PR DESCRIPTION
## Proposed Changes

- Change pattern from `/editpage\.action\?pageId=\d+$/` to `/editpage\.action$/`

## Details

### Change pattern from `/editpage\.action\?pageId=\d+$/` to `/editpage\.action$/`

The reason why we change the pattern is because not all **edit page** is in the pattern `/editpage\.action\?pageId=\d+$/`.

For example, when you resume a draft in a edit page. After the page refreshed, the url will changed to `/editpage.action`.