### PR TITLE
fix: test settings and separate webpack config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,7 +14,7 @@ module.exports = {
   settings: {
     'import/resolver': {
       webpack: {
-        config: 'webpack.config.js',
+        config: 'webpack.common.js',
       },
     },
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -17574,6 +17574,15 @@
         "uuid": "^3.3.2"
       }
     },
+    "webpack-merge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.2.tgz",
+      "integrity": "sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.15"
+      }
+    },
     "webpack-node-externals": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-1.7.2.tgz",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "test": "cross-env NODE_ENV=test mocha-webpack --webpack-config webpack.test.js --require tests/unit/setup.js tests/unit/**/*.spec.*",
     "test:watch": "cross-env NODE_ENV=test mocha-webpack --watch --webpack-config webpack.test.js --require tests/unit/setup.js tests/unit/**/*.spec.*",
-    "build": "cross-env NODE_ENV=production webpack --config webpack.config.js",
+    "build": "cross-env NODE_ENV=production webpack --config webpack.prod.js",
     "lint": "cross-env NODE_ENV=development eslint 'src/**/*.*'",
     "storybook": "cross-env NODE_ENV=development start-storybook -p 6006",
     "build-storybook": "crossenv NODE_ENV=development build-storybook"
@@ -66,6 +66,7 @@
     "vuex-module-decorators": "^0.16.1",
     "webpack": "^4.41.5",
     "webpack-cli": "^3.3.10",
+    "webpack-merge": "^4.2.2",
     "webpack-node-externals": "^1.7.2"
   },
   "dependencies": {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,16 +1,10 @@
 const path = require('path');
 const config = require('./config');
 const VueLoaderPlugin = require("vue-loader/lib/plugin")
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const CopyPlugin = require('copy-webpack-plugin');
-
-const mode = process.env.NODE_ENV || 'production';
 
 module.exports = {
   target: 'web',
-
-  mode,
 
   entry: {
     index: './src/index.ts',
@@ -35,26 +29,11 @@ module.exports = {
           appendTsSuffixTo: [/\.vue$/],
         }
       },
-      {
-        test: /\.css$/,
-        use: [
-          MiniCssExtractPlugin.loader,
-          'css-loader'
-        ]
-      },
-      {
-        test: /\.html$/i,
-        loader: 'file-loader'
-      }
     ],
   },
 
   plugins:[
-    new CleanWebpackPlugin(),
     new VueLoaderPlugin(),
-    new MiniCssExtractPlugin({
-      filename: 'app.css'
-    }),
     new CopyPlugin([{ from: 'public' }]),
   ],
 
@@ -69,18 +48,7 @@ module.exports = {
     },
   },
 
-  // output: {
-  //   filename: '[name].js',
-  //   libraryTarget: 'global',
-  //   globalObject: 'this',
-  //   path: path.resolve(__dirname, 'dist'),
-  // },
   output: {
     path: path.resolve(__dirname, config.output),
   },
-
-  // Workaround of passing CSP (Content Security Policy) when using mode: development
-  // Stackoverflow: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed
-  // https://stackoverflow.com/a/49100966
-  devtool: 'cheap-module-source-map',
 };

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,0 +1,21 @@
+const merge = require('webpack-merge');
+const common = require('./webpack.common');
+
+module.exports = merge(common, {
+  mode: 'development',
+
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        use: [
+          'css-loader', // 1. Turns css into commonJS
+        ]
+      },
+    ],
+  },
+  // Workaround of passing CSP (Content Security Policy) when using mode: development
+  // Stackoverflow: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed
+  // https://stackoverflow.com/a/49100966
+  devtool: 'cheap-module-source-map',
+});

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,0 +1,27 @@
+const merge = require('webpack-merge');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
+const common = require('./webpack.common');
+
+module.exports = merge(common, {
+  mode: 'production',
+
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        use: [
+          MiniCssExtractPlugin.loader, // 2. Extract css into files
+          'css-loader', // 1. Turns css into commonJS
+        ]
+      },
+    ],
+  },
+
+  plugins:[
+    new CleanWebpackPlugin(),
+    new MiniCssExtractPlugin({
+      filename: 'app.css'
+    }),
+  ],
+});

--- a/webpack.test.js
+++ b/webpack.test.js
@@ -1,5 +1,6 @@
 const nodeExternals = require('webpack-node-externals');
-const config = require('./webpack.config');
+const merge = require('webpack-merge');
+const dev = require('./webpack.dev');
 
 // Override the config of vue-loader
 // The default value of this option is `true` when `target: node`,
@@ -10,13 +11,9 @@ const config = require('./webpack.config');
 // The workaround is setting `optimizeSSR` to false.
 // https://github.com/vuejs/vue-loader/issues/885#issuecomment-375802186
 // https://vue-loader-v14.vuejs.org/ja/options.html#optimizessr
-config.module.rules[0].options.optimizeSSR = false;
+dev.module.rules[0].options.optimizeSSR = false;
 
-module.exports = {
-  ...config,
-
-  mode: 'development',
-
+module.exports = merge(dev, {
   // In order to use JSDOM for testing dom's modifications,
   // `target` should be set to `node`.
   target: 'node',
@@ -27,4 +24,4 @@ module.exports = {
     nodeExternals(), // in order to ignore all modules in node_modules folder from bundling
     // { jsdom: 'jsdom' },
   ],
-};
+});


### PR DESCRIPTION
## Proposed Changes

- Move common parts in `webpack.config.js` to `webpack.common.js` and separate dev/prod configs
- Add dev-dependency `webpack-merge`

## Details

### Move common parts in `webpack.config.js` to `webpack.common.js` and separate dev/prod configs

Prod: Apply `MiniCssExtractPlugin`, `CleanWebpackPlugin`.
Dev: Apply `cheap-module-source-map`