### PR TITLE
refactor: change the return type of findAll

### DIFF
--- a/src/models/domain-repository-impl.ts
+++ b/src/models/domain-repository-impl.ts
@@ -54,11 +54,10 @@ export default class DomainRepositoryImpl implements DomainRepository {
 
   /**
    * Return all domain contains in storage.
-   * @returns the domain list.
+   * @returns object contains domain with unique id respectively.
    */
-  async findAll(): Promise<Domain[]> {
-    const domains = await this.storage.get();
-    return Object.values(domains);
+  async findAll(): Promise<{ [id: string]: Domain }> {
+    return this.storage.get();
   }
 
   /**

--- a/src/models/domain-repository.ts
+++ b/src/models/domain-repository.ts
@@ -29,12 +29,10 @@ interface DomainRepository extends AsynchronizedRepository<string, Domain> {
   find(id: string): Promise<Domain | undefined>;
 
   /**
-   * Find a specific domain by id.
-   * If the id exist, then the corresponding domain will be returned.
-   * Otherwise, undefined will be returned.
-   * @param id the id of such domain.
+   * Return all domain contains in storage.
+   * @returns object contains domain with unique id respectively.
    */
-  findAll(): Promise<Domain[]>;
+  findAll(): Promise<{ [id: string]: Domain }>;
 
   /**
    * Remove a specific domain by id.

--- a/src/models/repository.ts
+++ b/src/models/repository.ts
@@ -5,7 +5,7 @@ export interface AsynchronizedRepository<Id, T> {
 
   find(id: Id): Promise<T | undefined>;
 
-  findAll(): Promise<T[]>;
+  findAll(): Promise<{ [id: string]: T }>;
 
   remove(id: Id): Promise<void>;
 }

--- a/tests/unit/models/domain-repository.spec.ts
+++ b/tests/unit/models/domain-repository.spec.ts
@@ -108,21 +108,22 @@ describe('DomainRepository', () => {
       // Verifications
       mock.get.verify();
       mock.set.verify();
-      expect(res).toEqual([]);
+      expect(res).toEqual({});
     });
 
     it('returns all records', async () => {
       const domain1 = { name: 'domain1' };
       const domain2 = { name: 'domain2' };
+      const records = { id1: domain1, id2: domain2 }
       // Conditions
-      mock.get.once().returns(Promise.resolve({ id1: domain1, id2: domain2 }));
+      mock.get.once().returns(Promise.resolve(records));
       mock.set.never();
       // Run
       const res = await domainRepository.findAll();
       // Verifications
       mock.get.verify();
       mock.set.verify();
-      expect(res.sort()).toEqual([domain1, domain2].sort());
+      expect(res).toEqual(records);
     });
   });
 


### PR DESCRIPTION
## Proposed changes

- Fix wrong function document
- Change return type of findAll from `Promise<T[]>` to `Promise<{[ id: string]: T }>`

## Details

### Fix wrong function document

The document of `DomainRepository#findAll` is incorrect (which was the content of `find`).

### Change return type of findAll from `Promise<T[]>` to `Promise<{[ id: string]: T }>`

Since `findAll` didn't return `id`s, we cannot use `id` to call either `update` or `remove`.

Currently, we change the return type to get each `id` of item respectively.