### PR TITLE
chore: change status badge and separate workflow into `build` and `pull request`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,8 @@
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: Node.js CI
+# Note: this name will be displayed on the state badge
+name: build
 
 # Define triggers
 # https://help.github.com/ja/actions/reference/workflow-syntax-for-github-actions#on
@@ -22,12 +23,12 @@ jobs:
     steps:
     - name: Checkout latest repository
       uses: actions/checkout@v2
-      
+
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    
+
     # Save and restore from caches
     # For more information,
     # see: https://github.com/actions/cache/blob/f60097cd16988b176c31ed5e2db51d50a8d19a4e/examples.md#node---npm

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,28 +1,30 @@
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-# Note: this name will be displayed on the state badge
-name: build
+name: pull request
 
 # Define triggers
 # https://help.github.com/ja/actions/reference/workflow-syntax-for-github-actions#on
 on:
-  push:
-    branches: [ master ]
+  pull_request:
 
 jobs:
   build:
 
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        node-version: [10.x, 11.x]
+
     steps:
     - name: Checkout latest repository
       uses: actions/checkout@v2
 
-    - name: Use Node.js 11.x
+    - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
-        node-version: 11.x
+        node-version: ${{ matrix.node-version }}
 
     # Save and restore from caches
     # For more information,
@@ -41,9 +43,3 @@ jobs:
     - run: npm ci
     - run: npm run build --if-present
     - run: npm test
-
-    - name: Upload to artifact
-      uses: actions/upload-artifact@v1
-      with:
-        name: dist
-        path: ./dist

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Confluence markdown editor chrome extension
 
-[![CircleCI](https://circleci.com/gh/ibara1454/confluence-markdown-editor-chrome-extension.svg?style=shield)](https://circleci.com/gh/ibara1454/confluence-markdown-editor-chrome-extension)
+![GitHub Actions](https://github.com/ibara1454/confluence-markdown-editor-chrome-extension/workflows/build/badge.svg)
 
 A Chrome extension provides Markdown editor for Confluence.
 


### PR DESCRIPTION
## Proposed Changes

- Separate the `Node.js CI` workflow into `build` and `pull request`
- Replace the status badge from CircleCI to GitHub Actions

## Details

### Separate the `Node.js CI` workflow into `build` and `pull request`

We replaced the original `Node.js CI` workflow by `build` since which name will be display on badge.
<img src="https://user-images.githubusercontent.com/4210652/78376616-89fc0680-7609-11ea-849f-78f0408b380c.png" width=100>

And for uploading the artifacts after builds, we separated the workflow into `build` and `pull request`. Now artifacts will be uploaded after `build`.

### Replace the status badge from CircleCI to GitHub Actions

As title, just replaced the badge.