### PR TITLE
fix: several bugs

### DIFF
--- a/config.js
+++ b/config.js
@@ -2,6 +2,10 @@
  * The general config module.
  */
 module.exports = {
-  // Output directory for webpack
-  output: 'dist',
+  // Name of each entrypoint
+  module: {
+    background: 'background',
+    plugin: 'plugin',
+    browser_action: 'index',
+  },
 };

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -23,7 +23,7 @@
 
   "content_scripts": [
     {
-      "matches": ["https://CONFLUENCE_PAGE/*"],
+      "matches": ["http://*/*", "https://*/*"],
       "js": ["plugin.js"],
       "css": []
     }

--- a/src/pages/Editor.vue
+++ b/src/pages/Editor.vue
@@ -20,7 +20,7 @@ export default Vue.extend({
 
   computed: {
     computedUrl(): string {
-      return getExternalUrl('app.css');
+      return getExternalUrl('plugin.css');
     },
 
     computedText: {

--- a/src/pages/Editor.vue
+++ b/src/pages/Editor.vue
@@ -11,6 +11,7 @@ import Vue from 'vue';
 import Context from '@/components/Context.vue';
 import MarkdownEditor from '@/components/MarkdownEditor.vue';
 import editorStore from '@/store/modules/editor';
+import config from 'config';
 import { getExternalUrl } from '@/utils';
 
 export default Vue.extend({
@@ -20,7 +21,9 @@ export default Vue.extend({
 
   computed: {
     computedUrl(): string {
-      return getExternalUrl('plugin.css');
+      // Resolve the related stylesheet of plugin
+      // TODO: remove the dependency to plugin from this component
+      return getExternalUrl(`${config.module.plugin}.css`);
     },
 
     computedText: {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -107,7 +107,7 @@ function setup(): void {
  */
 function isTargetPage(url: string): boolean {
   // The url pattern of editpage
-  const EDITPAGE_PATTERN = /editpage\.action$/;
+  const EDITPAGE_PATTERN = /editpage\.action/;
   // The url pattern of createpage
   const CREATEPAGE_PATTERN = /createpage\.action/;
   // Determine the given url whether it is "editpage" or "createpage"

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -8,9 +8,9 @@ module.exports = {
   target: 'web',
 
   entry: {
-    index: './src/index.ts',
-    plugin: './src/plugin.ts',
-    background: './src/background.ts',
+    [config.module.browser_action]: './src/index.ts',
+    [config.module.plugin]: './src/plugin.ts',
+    [config.module.background]: './src/background.ts',
   },
 
   module: {
@@ -95,6 +95,7 @@ module.exports = {
   },
 
   output: {
-    path: path.resolve(__dirname, config.output),
+    filename: '[name].js',
+    path: path.resolve(__dirname, 'dist'),
   },
 };


### PR DESCRIPTION
## Proposed Changes

- Correct the **editpage** pattern
- Correct the path to **plugin's stylesheet**
- Replace the dummy **matcher** pattern with wildcard

## Details

### Correct the **editpage** pattern

We set a wrong pattern to editpage in #4 .

Since the editpage may be `/editpage.action?pageId=123456` or `/editpage.action`, the correct pattern should be the regexp `/editpage\.action/`.

### Correct the path to **plugin's stylesheet**

We change the plugin script's name but forgot to change the path to stylesheet #8 .

### Replace the dummy **matcher** pattern with wildcard

As title, we just replaced the matcher with wildcard.