### PR TITLE
fix: problem of the module initializing before registered

### DIFF
--- a/src/entrypoints/browser_action/App.vue
+++ b/src/entrypoints/browser_action/App.vue
@@ -105,5 +105,9 @@ export default Vue.extend({
       DomainStore.remove(id);
     },
   },
+
+  beforeCreate() {
+    DomainStore.init();
+  },
 });
 </script>

--- a/src/store/modules/domain.ts
+++ b/src/store/modules/domain.ts
@@ -97,8 +97,4 @@ class DomainModule extends VuexModule {
   }
 }
 
-const domainStore = getModule(DomainModule);
-
-export default domainStore;
-
-domainStore.init();
+export default getModule(DomainModule);


### PR DESCRIPTION
## Proposed Changes

- The bug that `DomainModule#init` may called before registered

## Details

### The bug that `DomainModule#init` may called before registered

This occurs on OSX chrome 80.0.3987.163（Official Build）