### PR TITLE
fix: https pattern and add new 'resumedraft' pattern

### DIFF
--- a/src/entrypoints/plugin/index.ts
+++ b/src/entrypoints/plugin/index.ts
@@ -42,8 +42,10 @@ async function isTargetPage(url: string): Promise<boolean> {
   return Object.values(domains)
     .map((x) => x.name)
     .map(escapeRegExp)
-    // The url pattern of editpage or createpage
-    .map((domain) => new RegExp(String.raw`http(s)://${domain}/(.*/)?(editpage|createpage).action`))
+    // The url pattern of
+    //  Confluence 6.15.x - editpage.action or createpage.action
+    //  Confluence 6.13.x - resumedraft.action
+    .map((domain) => new RegExp(String.raw`https?://${domain}/(.*/)?(editpage|createpage|resumedraft).action`))
     // Determine the given url whether it is "editpage" or "createpage"
     .some((regexp) => regexp.test(url));
 }


### PR DESCRIPTION
## Proposed Changes

- Fix wrong syntax of regexp of page pattern
- Add new page pattern

## Details

### Fix wrong syntax of regexp of page pattern

`http(s)` is not the right pattern to match both 'http' and 'https'. We change it to `https?` instead.

### Add new page pattern

We noticed that the edit page is in the pattern of 
`http://DOMAIN/pages/editpage.action?id=65614` in Confluence `6.15.x`,
while
`http://DOMAIN/pages/resumedraft.action?draftId=xxxx&draftShareId=xxxx` in Confluence `6.13.x`
Hence we modified the matcher to match both patterns.