### PR TITLE
fix: duplicated launch

### DIFF
--- a/src/entrypoints/plugin/index.ts
+++ b/src/entrypoints/plugin/index.ts
@@ -13,13 +13,22 @@ const domainRepository = container.resolve(DomainRepository);
  */
 function setup(): void {
   // TODO: (feat) auto enable markdown editor
-  const app = document.createElement('div');
-  document.body.appendChild(app);
-  const vue = new Vue({
-    store,
-    render: (h) => h(App),
-  });
-  vue.$mount(app);
+  // Use the extension's id to avoid collisions
+  const id = chrome.runtime.id;
+  // Avoid double launch
+  if (document.getElementById(id) === null) {
+    const wrapper = document.createElement('div');
+    wrapper.id = id;
+    document.body.appendChild(wrapper);
+
+    const app = document.createElement('div');
+    wrapper.appendChild(app);
+    const vue = new Vue({
+      store,
+      render: (h) => h(App),
+    });
+    vue.$mount(app);
+  }
 }
 
 /**


### PR DESCRIPTION
## Proposed Changes

- Fix the bug that the application may be launched twice

## Details

Currently, the trigger inside of `content_script` is **URL changes**.
That trigger may be triggered over twice in the same page.
To solve the problem, the `setup` function will now detect the existence of application. If there is already an application exists, then `setup` will do nothing.