### PR TITLE
fix: remove unused permission and add URL permission

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -14,7 +14,9 @@
   },
 
   "permissions": [
-    "tabs", "webNavigation", "history", "storage"
+    "tabs",
+    "storage",
+    "<all_urls>"
   ],
 
   "background": {
@@ -23,7 +25,7 @@
 
   "content_scripts": [
     {
-      "matches": ["http://*/*", "https://*/*"],
+      "matches": ["<all_urls>"],
       "js": ["plugin.js"],
       "css": []
     }


### PR DESCRIPTION
## Proposed Changes

- Remove unused permission
- Add URL permission `<all_url>`

## Details

### Remove unused permission

Removed unused
- `webNavigation`: Gives your extension access to the `chrome.webNavigation` API.
- `history`: Gives your extension access to the `chrome.history` API.

Reference: https://developer.chrome.com/extensions/declare_permissions

### Add URL permission `<all_url>`

Add this permission to allow content_script be evaluated in each page.

Consider this permission could or could not replaced by `activeTab`.

https://developer.chrome.com/extensions/permission_warnings#activeTab_permission