### PR TITLE
feat: apply editor style in confluence page

### DIFF
--- a/src/components/MarkdownEditor.vue
+++ b/src/components/MarkdownEditor.vue
@@ -75,9 +75,6 @@ export default Vue.extend({
 </script>
 
 <style scoped>
-/* TODO: remove this temp css style */
-@import '~highlight.js/styles/github.css';
-
 /* TODO: remove min-height */
 .editor {
   display: flex;

--- a/src/pages/Editor.vue
+++ b/src/pages/Editor.vue
@@ -2,12 +2,14 @@
   <context id="confluence-markdown-editor">
     <!-- Load stylesheet again, since outside style cannot effect on inner frame -->
     <link type="text/css" rel="stylesheet" :href="computedUrl">
+    <v-style>{{ computedEditorStyle }}</v-style>
     <markdown-editor class="editor" v-model="computedText" />
   </context>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
+import VStyle from '@/basics/VStyle.vue';
 import Context from '@/components/Context.vue';
 import MarkdownEditor from '@/components/MarkdownEditor.vue';
 import editorStore from '@/store/modules/editor';
@@ -17,13 +19,17 @@ import { getExternalUrl } from '@/utils';
 export default Vue.extend({
   name: 'Editor',
 
-  components: { Context, MarkdownEditor },
+  components: { Context, MarkdownEditor, VStyle },
 
   computed: {
     computedUrl(): string {
       // Resolve the related stylesheet of plugin
       // TODO: remove the dependency to plugin from this component
       return getExternalUrl(`${config.module.plugin}.css`);
+    },
+
+    computedEditorStyle(): string {
+      return editorStore.EDITOR_STYLE;
     },
 
     computedText: {

--- a/src/store/modules/editor.ts
+++ b/src/store/modules/editor.ts
@@ -3,34 +3,142 @@ import {
 } from 'vuex-module-decorators';
 import store from '@/store';
 
+// TODO: make this style text modifiable
+const editorStyle = `
+/*
+
+github.com style (c) Vasily Polovnyov <vast@whiteants.net>
+
+*/
+
+.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 0.5em;
+  color: #333;
+  background: #f8f8f8;
+}
+
+.hljs-comment,
+.hljs-quote {
+  color: #998;
+  font-style: italic;
+}
+
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-subst {
+  color: #333;
+  font-weight: bold;
+}
+
+.hljs-number,
+.hljs-literal,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-tag .hljs-attr {
+  color: #008080;
+}
+
+.hljs-string,
+.hljs-doctag {
+  color: #d14;
+}
+
+.hljs-title,
+.hljs-section,
+.hljs-selector-id {
+  color: #900;
+  font-weight: bold;
+}
+
+.hljs-subst {
+  font-weight: normal;
+}
+
+.hljs-type,
+.hljs-class .hljs-title {
+  color: #458;
+  font-weight: bold;
+}
+
+.hljs-tag,
+.hljs-name,
+.hljs-attribute {
+  color: #000080;
+  font-weight: normal;
+}
+
+.hljs-regexp,
+.hljs-link {
+  color: #009926;
+}
+
+.hljs-symbol,
+.hljs-bullet {
+  color: #990073;
+}
+
+.hljs-built_in,
+.hljs-builtin-name {
+  color: #0086b3;
+}
+
+.hljs-meta {
+  color: #999;
+  font-weight: bold;
+}
+
+.hljs-deletion {
+  background: #fdd;
+}
+
+.hljs-addition {
+  background: #dfd;
+}
+
+.hljs-emphasis {
+  font-style: italic;
+}
+
+.hljs-strong {
+  font-weight: bold;
+}
+`;
+
+// TODO: make this style text modifiable
+const globalStyle = `
+#rte {
+  position: relative !important;
+}
+
+#confluence-markdown-editor {
+  position: absolute !important;
+  top: 80px !important;
+  bottom: 0 !important;
+  left: 0 !important;
+  right: 0 !important;
+  height: calc(100% - 80px) !important;
+  border: 0 !important;
+  margin: 0 !important;
+}
+
+#toolbar {
+  display: block !important;
+  height: 0 !important;
+  overflow-x: hidden !important;
+}
+`;
+
 @Module({ dynamic: true, store, name: 'Editor' })
 class EditorModule extends VuexModule {
   private text = '';
 
   // Change the position of parent be difference from static, so that
   // the child with style `position: absolute` could works fine.
-  private globalStyle = `
-  #rte {
-    position: relative !important;
-  }
+  private globalStyle = globalStyle;
 
-  #confluence-markdown-editor {
-    position: absolute !important;
-    top: 80px !important;
-    bottom: 0 !important;
-    left: 0 !important;
-    right: 0 !important;
-    height: calc(100% - 80px) !important;
-    border: 0 !important;
-    margin: 0 !important;
-  }
-
-  #toolbar {
-    display: block !important;
-    height: 0 !important;
-    overflow-x: hidden !important;
-  }
-  `;
+  private editorStyle = editorStyle;
 
   public get TEXT(): string {
     return this.text;
@@ -38,6 +146,10 @@ class EditorModule extends VuexModule {
 
   public get GLOBAL_STYLE(): string {
     return this.globalStyle;
+  }
+
+  public get EDITOR_STYLE(): string {
+    return this.editorStyle;
   }
 
   @Mutation


### PR DESCRIPTION
## Proposed Changes

- Remove the static style import in `MarkdownEditor.vue`
- Import style dynamically via vuex in `Editor.vue` and `TextField.vue`
- Request additional `highlight.js` library from CDN