### PR TITLE
refactor&feat: apply css style on parsed markdown document

### DIFF
--- a/src/basics/VScript.vue
+++ b/src/basics/VScript.vue
@@ -1,0 +1,17 @@
+<script lang="ts">
+import Vue from 'vue';
+
+export default Vue.extend({
+  name: 'VScript',
+
+  functional: true,
+
+  render(h, ctx) {
+    return h(
+      'script',
+      ctx.data,
+      ctx.children,
+    );
+  },
+});
+</script>

--- a/src/basics/VScript.vue
+++ b/src/basics/VScript.vue
@@ -1,6 +1,14 @@
 <script lang="ts">
 import Vue from 'vue';
 
+/**
+ * Same as native script tags.
+ * This class is one of the workarounds for that you can't use native script
+ * tags in template.
+ * You can use this component to add a import of a third-part library or
+ * a run short script - just like native `script` tag.
+ * @displayName VScript
+ */
 export default Vue.extend({
   name: 'VScript',
 

--- a/src/basics/VScript.vue
+++ b/src/basics/VScript.vue
@@ -12,6 +12,9 @@ import Vue from 'vue';
 export default Vue.extend({
   name: 'VScript',
 
+  // Note: use functional component to let this component transparently.
+  // That is, you will get the raw `<script/>` but not encapsulated `<vue-component-xx/>`
+  // when you use `vm.$el.innerText`.
   functional: true,
 
   render(h, ctx) {

--- a/src/components/confluence/HtmlMacro.vue
+++ b/src/components/confluence/HtmlMacro.vue
@@ -30,35 +30,39 @@ export default Vue.extend({
   name: 'HtmlMacro',
 
   data() {
+    // The raw text of default slot
     return { slot: '' };
   },
 
   methods: {
+    /**
+     * Render the given vnodes into strings instead of DOMs.
+     */
     renderString(vnodes: VNode[] | undefined): string {
+      // The easiest way to get the rendered vnodes is getting them from `vm.$el.innerHTML`
+      // You can do it by other ways
       const vm = new Vue({
-        render(h) {
-          return h('div', vnodes);
-        },
+        render: (h) => h('div', vnodes),
       });
-      //
+      // Render off-document
+      // See https://vuejs.org/v2/api/index.html#vm-mount
       vm.$mount();
-      // const s = new XMLSerializer();
-      // const str = Array.from(vm.$el.childNodes)
-      //   .map((node) => s.serializeToString(node))
-      //   .join('');
-      // console.log(str);
-      const str = vm.$el.innerHTML;
-      // https://developer.mozilla.org/ja/docs/Web/API/Node/textContent
-      return str;
+      // Get the raw DOM text rendered by vue
+      const rawDomText = vm.$el.innerHTML;
+      // Clean vm after used
+      vm.$destroy();
+      return rawDomText;
     },
   },
 
   created() {
+    // Get the raw text of default slot but not the DOM elements
     // eslint-disable-next-line dot-notation
     this.slot = this.renderString(this.$slots['default']);
   },
 
   beforeUpdate() {
+    // Get the raw text of default slot but not the DOM elements
     // eslint-disable-next-line dot-notation
     this.slot = this.renderString(this.$slots['default']);
   },

--- a/src/components/confluence/HtmlMacro.vue
+++ b/src/components/confluence/HtmlMacro.vue
@@ -1,0 +1,68 @@
+<template>
+  <!-- eslint-disable max-len -->
+  <table
+    class="wysiwyg-macro"
+    data-macro-name="html"
+    data-macro-schema-version="1"
+    style="background-image: url(/plugins/servlet/confluence/placeholder/macro-heading?definition=e2h0bWx9&amp;locale=ja_JP&amp;version=2); background-repeat: no-repeat;"
+    data-macro-body-type="PLAIN_TEXT"
+    data-mce-selected="1"
+  >
+  <!-- eslint-enable max-len -->
+    <tbody>
+      <tr>
+        <td class="wysiwyg-macro-body">
+          <pre v-text="slot"></pre>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</template>
+
+<script lang="ts">
+import Vue, { VNode } from 'vue';
+
+/**
+ * The Raw HTML macro of confluence.
+ * @displayName HtmlMacro
+ */
+export default Vue.extend({
+  name: 'HtmlMacro',
+
+  data() {
+    return { slot: '' };
+  },
+
+  methods: {
+    renderString(vnodes: VNode[] | undefined): string {
+      const vm = new Vue({
+        render(h) {
+          return h('div', vnodes);
+        },
+      });
+      //
+      vm.$mount();
+      // const s = new XMLSerializer();
+      // const str = Array.from(vm.$el.childNodes)
+      //   .map((node) => s.serializeToString(node))
+      //   .join('');
+      // console.log(str);
+      const str = vm.$el.innerHTML;
+      // https://developer.mozilla.org/ja/docs/Web/API/Node/textContent
+      return str;
+    },
+  },
+
+  created() {
+    // eslint-disable-next-line dot-notation
+    this.slot = this.renderString(this.$slots['default']);
+  },
+
+  beforeUpdate() {
+    // eslint-disable-next-line dot-notation
+    this.slot = this.renderString(this.$slots['default']);
+  },
+});
+
+
+</script>

--- a/src/models/confluence-page.ts
+++ b/src/models/confluence-page.ts
@@ -1,0 +1,33 @@
+/**
+ * This interface indicates contents inside a confluence page.
+ */
+interface ConfluencePage {
+  /**
+   * The main field which contains the markdown text.
+   */
+  text: string;
+
+  /**
+   * Raw string of customized style for parsed markdown.
+   */
+  style: string;
+}
+
+export default ConfluencePage;
+
+/**
+ * Parse the given doc and convert it into ConfluencePage.
+ * @param doc a Document.
+ * @returns ConfluencePage or undefined if any error occured.
+ */
+export function parseConfluencePage(doc: Document): ConfluencePage | undefined {
+  const child = doc.body?.firstElementChild;
+  if (child && child.tagName === 'PRE') {
+    const text = (child as HTMLElement).innerText;
+    return {
+      text,
+      style: '',
+    };
+  }
+  return undefined;
+}

--- a/src/pages/TextField.vue
+++ b/src/pages/TextField.vue
@@ -22,42 +22,48 @@
   <pre>{{ computedText }}</pre>
   <!-- eslint-disable max-len -->
   <html-macro>
-    <v-script type="text/template">{{ computedEditorStyle }}</v-script>
+    <v-script type="text/template" id="confluence-markdown-editor-global-style">
+      {{ computedEditorStyle }}
+    </v-script>
     <v-script defer>
-      const main = document.getElementById('main-content');
-      const text = main.firstElementChild.innerText;
-      const iframe = document.createElement('iframe');
-      main.innerHTML = '';
-      main.appendChild(iframe);
+      (function() {
+        const main = document.getElementById('main-content');
+        const text = main.firstElementChild.innerText;
+        const style = main.querySelector('#confluence-markdown-editor-global-style').innerText;
+        const iframe = document.createElement('iframe');
+        main.innerHTML = ''; // Remove all content in main-content
+        main.appendChild(iframe);
 
-      const markedLoaded = new Promise((resolve) => {
-        const script = document.createElement('script');
-        script.src = "https://cdnjs.cloudflare.com/ajax/libs/marked/0.8.0/marked.min.js";
-        document.body.appendChild(script);
-        script.onload = resolve;
-      });
-
-      const hightlightLoaded = new Promise((resolve) => {
-        const script = document.createElement('script');
-        script.src = "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/highlight.min.js";
-        document.body.appendChild(script);
-        script.onload = resolve;
-      });
-
-      Promise.all([markedLoaded, hightlightLoaded]).then(() => {
-        marked.setOptions({
-          highlight: (code, lang) => {
-            const result = lang !== '' ? hljs.highlightAuto(code, [lang]) : hljs.highlightAuto(code);
-            return result.value;
-          },
+        const markedLoaded = new Promise((resolve) => {
+          const script = document.createElement('script');
+          script.src = "https://cdnjs.cloudflare.com/ajax/libs/marked/0.8.0/marked.min.js";
+          document.body.appendChild(script);
+          script.onload = resolve;
         });
-        iframe.contentDocument.body.innerHTML = marked(text);
-        iframe.contentDocument.body.style = 'margin: 0; overflow-y: hidden;';
-        iframe.style = 'width: 100%; border: 0;';
-        iframe.style.height = iframe.contentDocument.body.offsetHeight + 'px';
-        const style = iframe.contentDocument.createElement('style');
-        iframe.contentDocument.body.appendChild(style);
-      });
+
+        const hightlightLoaded = new Promise((resolve) => {
+          const script = document.createElement('script');
+          script.src = "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/highlight.min.js";
+          document.body.appendChild(script);
+          script.onload = resolve;
+        });
+
+        Promise.all([markedLoaded, hightlightLoaded]).then(() => {
+          marked.setOptions({
+            highlight: (code, lang) => {
+              const result = lang !== '' ? hljs.highlightAuto(code, [lang]) : hljs.highlightAuto(code);
+              return result.value;
+            },
+          });
+          iframe.contentDocument.body.innerHTML = marked(text);
+          iframe.contentDocument.body.style = 'margin: 0; overflow-y: hidden;';
+          iframe.style = 'width: 100%; border: 0;';
+          iframe.style.height = iframe.contentDocument.body.offsetHeight + 'px';
+          const styleTag = iframe.contentDocument.createElement('style');
+          styleTag.innerText = style;
+          iframe.contentDocument.body.appendChild(styleTag);
+        });
+      })();
     </v-script>
   </html-macro>
 </body>

--- a/src/pages/TextField.vue
+++ b/src/pages/TextField.vue
@@ -21,78 +21,63 @@
 >
   <pre>{{ computedText }}</pre>
   <!-- eslint-disable max-len -->
-  <table
-    class="wysiwyg-macro"
-    data-macro-name="html"
-    data-macro-schema-version="1"
-    style="background-image: url(/plugins/servlet/confluence/placeholder/macro-heading?definition=e2h0bWx9&amp;locale=ja_JP&amp;version=2); background-repeat: no-repeat;"
-    data-macro-body-type="PLAIN_TEXT"
-    data-mce-selected="1"
-  >
-  <!-- eslint-enable max-len -->
-    <tbody>
-      <tr>
-        <td class="wysiwyg-macro-body">
-          <pre>{{ computedContent }}</pre>
-        </td>
-      </tr>
-    </tbody>
-  </table>
+  <html-macro>
+    <v-script type="text/template">{{ computedEditorStyle }}</v-script>
+    <v-script defer>
+      const main = document.getElementById('main-content');
+      const text = main.firstElementChild.innerText;
+      const iframe = document.createElement('iframe');
+      main.innerHTML = '';
+      main.appendChild(iframe);
+
+      const markedLoaded = new Promise((resolve) => {
+        const script = document.createElement('script');
+        script.src = "https://cdnjs.cloudflare.com/ajax/libs/marked/0.8.0/marked.min.js";
+        document.body.appendChild(script);
+        script.onload = resolve;
+      });
+
+      const hightlightLoaded = new Promise((resolve) => {
+        const script = document.createElement('script');
+        script.src = "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/highlight.min.js";
+        document.body.appendChild(script);
+        script.onload = resolve;
+      });
+
+      Promise.all([markedLoaded, hightlightLoaded]).then(() => {
+        marked.setOptions({
+          highlight: (code, lang) => {
+            const result = lang !== '' ? hljs.highlightAuto(code, [lang]) : hljs.highlightAuto(code);
+            return result.value;
+          },
+        });
+        iframe.contentDocument.body.innerHTML = marked(text);
+        iframe.contentDocument.body.style = 'margin: 0; overflow-y: hidden;';
+        iframe.style = 'width: 100%; border: 0;';
+        iframe.style.height = iframe.contentDocument.body.offsetHeight + 'px';
+        const style = iframe.contentDocument.createElement('style');
+        iframe.contentDocument.body.appendChild(style);
+      });
+    </v-script>
+  </html-macro>
 </body>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
+import VScript from '@/basics/VScript.vue';
+import HtmlMacro from '@/components/confluence/HtmlMacro.vue';
 import editorStore from '@/store/modules/editor';
-
-// TODO: refactor function
-function styleScript(rawStyle: string): string {
-  const quotedStyle = `\`${rawStyle}\``;
-  return `
-<${'script'}>
-const main = document.getElementById('main-content');
-const text = main.firstElementChild.innerText;
-const iframe = document.createElement('iframe');
-main.innerHTML = '';
-main.appendChild(iframe);
-
-const markedLoaded = new Promise((resolve) => {
-  const script = document.createElement('script');
-  script.src = "https://cdnjs.cloudflare.com/ajax/libs/marked/0.8.0/marked.min.js";
-  document.body.appendChild(script);
-  script.onload = resolve;
-});
-
-const hightlightLoaded = new Promise((resolve) => {
-  const script = document.createElement('script');
-  script.src = "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/highlight.min.js";
-  document.body.appendChild(script);
-  script.onload = resolve;
-});
-
-Promise.all([markedLoaded, hightlightLoaded]).then(() => {
-  marked.setOptions({
-    highlight: (code, lang) => {
-      const result = lang !== '' ? hljs.highlightAuto(code, [lang]) : hljs.highlightAuto(code);
-      return result.value;
-    },
-  });
-  iframe.contentDocument.body.innerHTML = marked(text);
-  iframe.contentDocument.body.style = 'margin: 0; overflow-y: hidden;';
-  iframe.style = 'width: 100%; border: 0;';
-  iframe.style.height = iframe.contentDocument.body.offsetHeight + 'px';
-  const style = iframe.contentDocument.createElement('style');
-  iframe.contentDocument.body.appendChild(style);
-  style.innerHTML = ${quotedStyle};
-});
-
-</${'script'}>
-`;
-}
 
 // TODO: set the height of component dynamically
 export default Vue.extend({
   name: 'TextField',
+
+  components: { VScript, HtmlMacro },
+
+  props: {
+    text: { type: String, required: true },
+  },
 
   computed: {
     computedText: {
@@ -102,13 +87,14 @@ export default Vue.extend({
       },
     },
 
-    computedContent(): string {
-      return styleScript(this.computedEditorStyle);
-    },
-
     computedEditorStyle(): string {
       return editorStore.EDITOR_STYLE;
     },
+  },
+
+  created() {
+    // Initialize the text state
+    editorStore.SET_TEXT(this.text);
   },
 });
 </script>

--- a/tests/unit/basics/VScript.spec.ts
+++ b/tests/unit/basics/VScript.spec.ts
@@ -1,0 +1,42 @@
+import expect from 'expect';
+import Vue from 'vue';
+import VScript from '@/basics/VScript.vue';
+
+// The usage of Vue.$createElement
+// See https://github.com/vuejs/vue/blob/52719ccab8fccffbdf497b96d3731dc86f04c1ce/test/unit/modules/vdom/create-element.spec.js
+describe('VScript', () => {
+  it('render basic script tag with inner text', () => {
+    const vue = new Vue({
+      render: (h) => h(VScript, ['inner text']),
+    });
+    vue.$mount();
+    expect(vue.$el.outerHTML).toEqual('<script>inner text</script>');
+  });
+
+  it('render async script tag with inner text', () => {
+    // attrs: { async: true } will let vue renders async="async"
+    // And there is no way to just render 'async'.
+    // FYI: https://github.com/vuejs/vue/blob/52719ccab8fccffbdf497b96d3731dc86f04c1ce/test/unit/modules/vdom/modules/attrs.spec.js
+    const vue = new Vue({
+      render: (h) => h(VScript, { attrs: { async: true } }, ['inner text']),
+    });
+    vue.$mount();
+    expect(vue.$el.outerHTML).toEqual('<script async="async">inner text</script>');
+  });
+
+  it('render defer script tag with inner text', () => {
+    const vue = new Vue({
+      render: (h) => h(VScript, { attrs: { defer: true } }, ['inner text']),
+    });
+    vue.$mount();
+    expect(vue.$el.outerHTML).toEqual('<script defer="defer">inner text</script>');
+  });
+
+  it('render script tag with src', () => {
+    const vue = new Vue({
+      render: (h) => h(VScript, { attrs: { src: 'http://dummy.link' } }),
+    });
+    vue.$mount();
+    expect(vue.$el.outerHTML).toEqual('<script src="http://dummy.link"></script>');
+  });
+});


### PR DESCRIPTION
## Proposed Changed

- Move global style (style of editor) from `applyStyle()` to `template`
- Apply markdown style after page load
- Add components: VScript, HtmlMacro

## Details

### Move global style (style of editor) from `applyStyle()` to `template`

As the title, we just append the style tag by using template instead of JavaScript function.

### Apply markdown style after page load

Implemented the WIP feature: Apply markdown style after page load.

Now highlight.js will be applied on markdown text, and also the stylesheet.

### Add components: VScript, HtmlMacro

For putting the script inside of macro by template instead of functinos, we create new VScript and HtmlMacro components.

**VScript**: render native `script` tag by render function, since you can't put a `script` tag in SFC.
**HtmlMacro**: component indicates the _HTML macro_ in confluence. This component renders the default slot into raw texts instead of DOMs.