### PR TITLE
fix: disable checkspell on markdown editor

### DIFF
--- a/src/components/TextEditor.vue
+++ b/src/components/TextEditor.vue
@@ -1,5 +1,6 @@
 <template>
   <v-textarea
+    spellcheck="false"
     v-model="computedValue"
     @keydown.native.prevent.exact.tab="indent"
     @keydown.native.prevent.exact.shift.tab="unIndent" />


### PR DESCRIPTION
## Proposed Changes

- Disabled checkspell in markdown editor (textarea)

## Details

Before:
![sample](https://user-images.githubusercontent.com/4210652/79636236-3107a300-81b1-11ea-83ed-327a84f3e8cc.gif)

After:
![コメント 2020-04-18 201642](https://user-images.githubusercontent.com/4210652/79636296-96f42a80-81b1-11ea-8fdf-4911bd96620f.png)
