### PR TITLE
fix: change version to valid range

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Confluence markdown editor",
   "description" : "Markdown editor for Confluence",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "manifest_version": 2,
   "icons": {
     "32": "icons/icon_32.png",


### PR DESCRIPTION
## Proposed changes

- change version to valid range

## Details

The current version (0.0.0) is not in the valid range. We changed it to `"1.0.0"`.
![コメント 2020-04-18 233042](https://user-images.githubusercontent.com/4210652/79640467-b9477180-81cc-11ea-8bc4-033073a95445.png)

[Manifest - Version](https://developer.chrome.com/extensions/manifest/version) indicates that version should in the range between 1 and 65535.
