### PR TITLE
fix: remove addition `min-height` style on markdown editor

### DIFF
--- a/src/components/MarkdownEditor.vue
+++ b/src/components/MarkdownEditor.vue
@@ -75,10 +75,8 @@ export default Vue.extend({
 </script>
 
 <style scoped>
-/* TODO: remove min-height */
 .editor {
   display: flex;
-  min-height: 300px;
   overflow: hidden;
 }
 


### PR DESCRIPTION
## Proposed Changes

- Remove addition `min-height` style on markdown editor

## Details

This causes the scrollbar shown when `height < 300px`.