### PR TITLE
refactor: move markdown text into macro

### DIFF
--- a/src/models/confluence-page.ts
+++ b/src/models/confluence-page.ts
@@ -21,12 +21,20 @@ export default ConfluencePage;
  * @returns ConfluencePage or undefined if any error occured.
  */
 export function parseConfluencePage(doc: Document): ConfluencePage | undefined {
-  const child = doc.body?.firstElementChild;
-  if (child && child.tagName === 'PRE') {
-    const text = (child as HTMLElement).innerText;
+  // Get contents from Confluence's html-macro
+  const macro = doc.querySelector('.wysiwyg-macro-body > pre');
+
+  if (macro && macro.textContent) {
+    const domparser = new DOMParser();
+    // Parse the text in macro by DOMParser
+    const template = domparser.parseFromString(macro.textContent, 'text/html');
+
+    const textDom = template.querySelector('#confluence-markdown-editor-markdown-text');
+    const styleDom = template.querySelector('#confluence-markdown-editor-markdown-style');
+
     return {
-      text,
-      style: '',
+      text: textDom?.textContent || '',
+      style: styleDom?.textContent || '',
     };
   }
   return undefined;

--- a/src/pages/TextField.vue
+++ b/src/pages/TextField.vue
@@ -19,19 +19,19 @@
   ]"
   style="padding-top: 108px;"
 >
-  <pre>{{ computedText }}</pre>
   <!-- eslint-disable max-len -->
   <html-macro>
-    <v-script type="text/template" id="confluence-markdown-editor-global-style">
+    <v-script type="text/template" id="confluence-markdown-editor-markdown-text">{{ computedText }}</v-script>
+    <v-script type="text/template" id="confluence-markdown-editor-markdown-style">
       {{ computedEditorStyle }}
     </v-script>
     <v-script defer>
       (function() {
         const main = document.getElementById('main-content');
-        const text = main.firstElementChild.innerText;
-        const style = main.querySelector('#confluence-markdown-editor-global-style').innerText;
+        const text = main.querySelector('#confluence-markdown-editor-markdown-text').textContent;
+        const style = main.querySelector('#confluence-markdown-editor-markdown-style').textContent;
         const iframe = document.createElement('iframe');
-        main.innerHTML = ''; // Remove all content in main-content
+        main.textContent = ''; // Remove all content in main-content
         main.appendChild(iframe);
 
         const markedLoaded = new Promise((resolve) => {
@@ -60,7 +60,7 @@
           iframe.style = 'width: 100%; border: 0;';
           iframe.style.height = iframe.contentDocument.body.offsetHeight + 'px';
           const styleTag = iframe.contentDocument.createElement('style');
-          styleTag.innerText = style;
+          styleTag.textContent = style;
           iframe.contentDocument.body.appendChild(styleTag);
         });
       })();


### PR DESCRIPTION
## Proposed Changes

- (breaking change) put markdown text into marcro
- Replace `innerText` by `textContent`

## Details

### Put markdown text into macro

For system extensibility, we move the markdown text from `<pre>` (outside of macro) into Confluence's HTML macro.

This makes our markdown text out of the Confluence TYSIWYG editor's control.

### Replace `innerText` by `textContent`

Reference: https://developer.mozilla.org/ja/docs/Web/API/Node/textContent

In our case, we don't need (and don't want) the rendered text but the raw text, `textContent` is more suitable for us.