### PR TITLE
fix: bug that returns undefined if record is not found

### DIFF
--- a/src/models/domain-storage-impl.ts
+++ b/src/models/domain-storage-impl.ts
@@ -53,7 +53,7 @@ export default class DomainStorageImpl implements DomainStorage {
    */
   async ['get'](): Promise<{ [key: string]: Domain }> {
     const resMap = await this.syncGet(this.domainKey);
-    return resMap[this.domainKey];
+    return resMap[this.domainKey] || {};
   }
 
   /**


### PR DESCRIPTION
## Proposed Changes

- Bug: returns undefined when no record found

## Details

Note this problem only occurs in **PRODUCTION** build. (Since development build doesn't use `DomainStorageImpl` for storage)

Since `resMap` is just a object, `Object#get` will return `undefined` if there is no matched key.
This is a simple error but the error was threw from [vuex-module-decorators](https://github.com/championswimmer/vuex-module-decorators).
So we couldn't recognize the main problem for the first time.

```
Uncaught (in promise) Error: ERR_ACTION_ACCESS_UNDEFINED: Are you trying to access this.someMutation() or this.someGetter inside an @Action? 
That works only in dynamic modules. 
If not dynamic use this.context.commit("mutationName", payload) and this.context.getters["getterName"]
Error: Could not perform action fetch
    at l.<anonymous> (chrome-extension://ngbagdkkjmhfaieelfpmmigaigpcajgp/index.js:1844:5518)
    at chrome-extension://ngbagdkkjmhfaieelfpmmigaigpcajgp/index.js:1844:1212
    at Object.next (chrome-extension://ngbagdkkjmhfaieelfpmmigaigpcajgp/index.js:1844:1317)
    at a (chrome-extension://ngbagdkkjmhfaieelfpmmigaigpcajgp/index.js:1844:85)
TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at Object.reset (chrome-extension://ngbagdkkjmhfaieelfpmmigaigpcajgp/index.js:37:12621)
    at l.i.mutations.<computed> (chrome-extension://ngbagdkkjmhfaieelfpmmigaigpcajgp/index.js:1844:5861)
    at chrome-extension://ngbagdkkjmhfaieelfpmmigaigpcajgp/index.js:1844:13008
    at chrome-extension://ngbagdkkjmhfaieelfpmmigaigpcajgp/index.js:1850:637
    at Array.forEach (<anonymous>)
    at chrome-extension://ngbagdkkjmhfaieelfpmmigaigpcajgp/index.js:1850:616
    at l._withCommit (chrome-extension://ngbagdkkjmhfaieelfpmmigaigpcajgp/index.js:1850:2160)
    at l.commit (chrome-extension://ngbagdkkjmhfaieelfpmmigaigpcajgp/index.js:1850:590)
    at Object.commit (chrome-extension://ngbagdkkjmhfaieelfpmmigaigpcajgp/index.js:1844:10591)
    at l.<anonymous> (chrome-extension://ngbagdkkjmhfaieelfpmmigaigpcajgp/index.js:1844:5249)
    at chrome-extension://ngbagdkkjmhfaieelfpmmigaigpcajgp/index.js:1844:1212
    at Object.next (chrome-extension://ngbagdkkjmhfaieelfpmmigaigpcajgp/index.js:1844:1317)
    at a (chrome-extension://ngbagdkkjmhfaieelfpmmigaigpcajgp/index.js:1844:85)
```