### PR TITLE
fix: change the initialize order to avoid empty initialization

### DIFF
--- a/src/components/MarkdownEditor.vue
+++ b/src/components/MarkdownEditor.vue
@@ -24,7 +24,7 @@ export default Vue.extend({
   components: { TextEditor, HtmlPreview },
 
   props: {
-    value: { type: String, required: false, default: '' },
+    value: { type: String, required: true },
   },
 
   data() {

--- a/src/entrypoints/plugin/App.vue
+++ b/src/entrypoints/plugin/App.vue
@@ -91,8 +91,8 @@ export default Vue.extend({
     clickOk(): void {
       this.dialog = false;
       this.launched = true;
-      setupEditor();
       setupTextField();
+      setupEditor();
     },
 
     clickCancel(): void {

--- a/tests/unit/components/MarkdownEditor.spec.ts
+++ b/tests/unit/components/MarkdownEditor.spec.ts
@@ -9,6 +9,7 @@ describe('MarkdownEditor', () => {
   it('has a input panel', () => {
     const wrapper = shallowMount(MarkdownEditor, {
       localVue,
+      propsData: { value: '' },
     });
     expect(wrapper.contains('.input')).toBeTruthy();
   });
@@ -16,14 +17,15 @@ describe('MarkdownEditor', () => {
   it('has a preview panel', () => {
     const wrapper = shallowMount(MarkdownEditor, {
       localVue,
+      propsData: { value: '' },
     });
     expect(wrapper.contains('.preview')).toBeTruthy();
   });
 
   it('rendered with given markdown input `#`', () => {
     const wrapper = shallowMount(MarkdownEditor, {
-      propsData: { value: '# Dummy text' },
       localVue,
+      propsData: { value: '# Dummy text' },
     });
     expect(wrapper.vm.$data.dataMarkdown).toBe('<h1 id="dummy-text">Dummy text</h1>\n');
   });


### PR DESCRIPTION
## Proposed Change

- Change the initialize order between `setupTextField` and `setupEditor`
- Add required restriction to props `value`

## Details

### Change the initialize order between `setupTextField` and `setupEditor`

Since the markdown text are loaded in setupTextField, we change the initialize order to make the load complete before `setupEditor`.

### Add required restriction to props `value`

Avoid empty value be set.